### PR TITLE
fix(pre-commit): Do not check .md

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,5 +34,5 @@ exclude: |
         ^raw_data/|
         ^docs/|
         ^tests/|
-        ^README\.md
+        .*\.md$
     )


### PR DESCRIPTION
This pull request includes a change to the `.pre-commit-config.yaml` file to broaden the exclusion criteria for markdown files.

* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9L37-R37): Updated the exclusion pattern to exclude all markdown files instead of just `README.md`.